### PR TITLE
Translation Fix: Language Exists

### DIFF
--- a/upload/admin/language/en-gb/localisation/language.php
+++ b/upload/admin/language/en-gb/localisation/language.php
@@ -27,7 +27,7 @@ $_['help_status']       = 'Hide/Show it in language dropdown.';
 
 // Error
 $_['error_permission']  = 'Warning: You do not have permission to modify languages!';
-$_['error_exists']      = 'Warning: You added before the language!';
+$_['error_exists']      = 'Warning: You have added this language already!';
 $_['error_name']        = 'Language Name must be between 3 and 32 characters!';
 $_['error_code']        = 'Language Code must at least 2 characters!';
 $_['error_locale']      = 'Locale required!';


### PR DESCRIPTION
Fixed a text error in the error_exists language output. This error displayed a text warning to the user when trying to add a new language with a code which already existed. Text didn't make sense.